### PR TITLE
Align About page with homepage style

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 
- <html>
+ <html class="about-page">
 
     <head>
 
@@ -50,7 +50,7 @@
 
 
 
-    <body>
+    <body class="about-page">
 
     
 
@@ -102,7 +102,7 @@
 
   <!-- About Hero -->
   <section class="row mt-5 about-wrap">
-    <div class="col-xs-12 col-md-10">
+    <div class="col-xs-12 col-md-10 col-md-offset-1">
       <h2 class="section-h left">About Poli Plot Labs</h2>
       <p class="about-lead">
         We turn complex policy data into clear, visual stories—

--- a/css/style.css
+++ b/css/style.css
@@ -25,7 +25,9 @@
 *::before,
 *::after{ box-sizing:border-box; }
 
-html{ -webkit-text-size-adjust:100%; text-size-adjust:100%; }
+html{ -webkit-text-size-adjust:100%; text-size-adjust:100%; background:#fff; }
+
+html.about-page{ font-size:18px; }
 
 body{
   margin:0;
@@ -34,6 +36,9 @@ body{
   background:#fff;
 }
 
+/* About page base adjustments */
+body.about-page{ background:#fff; }
+
 img{ max-width:100%; height:auto; display:block; }
 a{ color:#010101; text-decoration:none; transition:all .3s ease; }
 a:focus, img:focus, button:focus, .btn:focus{ outline:none; }
@@ -41,6 +46,13 @@ a:focus, img:focus, button:focus, .btn:focus{ outline:none; }
 
 main[role="main-home-wrapper"],
 main[role="main-inner-wrapper"]{ background:#fff; padding-bottom:90px; }
+
+/* Centered, narrower layout for About page */
+body.about-page main[role="main-inner-wrapper"]{
+  width:100%;
+  max-width:900px;
+  margin:0 auto;
+}
 
 /* Smooth transitions for common elements */
 body, img,


### PR DESCRIPTION
## Summary
- Center About page content within a narrower container and increase base font size for better readability.
- Ensure About page uses white background by default to remove gray margins.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af345796b883258a334164a6afdc89